### PR TITLE
Cleanup as much as adding new keys

### DIFF
--- a/IdentityServer3.Contrib.RedisStore/Stores/BaseTokenStore.cs
+++ b/IdentityServer3.Contrib.RedisStore/Stores/BaseTokenStore.cs
@@ -111,6 +111,14 @@ namespace IdentityServer3.Contrib.RedisStore.Stores
             {
                 await this.database.StringSetAsync(tokenKey, json, expiresIn).ConfigureAwait(false);
             }
+            
+            //allways cleanup any previous expired keys
+            var updateKey = keyGenerator.GetSetKey(tokenType, token.SubjectId);
+            var tokensKeys = await this.database.SetMembersAsync(updateKey).ConfigureAwait(false);
+            var tokens = await this.database.StringGetAsync(tokensKeys.Select(_ => (RedisKey)_.ToString()).ToArray()).ConfigureAwait(false);
+            var keysToDelete = tokensKeys.Zip(tokens, (deleteKey, value) => new KeyValuePair<RedisValue, RedisValue>(deleteKey, value)).Where(_ => !_.Value.HasValue).Select(_ => _.Key).ToArray();
+            if (keysToDelete.Count() != 0)
+                this.database.SetRemoveAsync(updateKey, keysToDelete).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Keys data grows as much as they are stored
It is a good oportunity to cleanup any previous expired keys.
This is needed in real life senarios where the number of keys is very high and memory consumption is a problem
Realeasing memory should be proportionnal to adding keys, so i think this should de added by default in this implementation.